### PR TITLE
fix: Don't set correlation ID on response

### DIFF
--- a/correlationid.go
+++ b/correlationid.go
@@ -48,7 +48,6 @@ func Middleware(c *gin.Context) {
 	if c.Request.Header.Get(Header) == "" {
 		c.Request.Header.Set(Header, strings.ToUpper(uuid.NewV4().String()))
 	}
-	c.Writer.Header().Set(Header, c.Request.Header.Get(Header))
 	c.Next()
 }
 


### PR DESCRIPTION
## About

We currently always set the Correlation ID header on the response before processing the rest of the middleware chain. If another middleware adds a Correlation ID later on, we have no way to de-duplicate this from withing the `krakend-correlationid` middleware; I think it's best to just set it in the respective middlewares.