### PR TITLE
fix: Don't set correlation-ID-header on response

### DIFF
--- a/correlationid.go
+++ b/correlationid.go
@@ -48,7 +48,6 @@ func Middleware(c *gin.Context) {
 	if c.Request.Header.Get(Header) == "" {
 		c.Request.Header.Set(Header, strings.ToUpper(uuid.NewV4().String()))
 	}
-	c.Writer.Header().Set(Header, c.Request.Header.Get(Header))
 	c.Next()
 }
 


### PR DESCRIPTION
## About

We currently set the `X-Correlation-Id` header on the response object before the request is processed by the `krakend` proxy pipeline. Since we have no control over how response headers are set by `krakend` internals, we cannot make sure that this doesn't result in multiple `X-Correlation-Id` headers with the same value. I suggest to leave it to other middlewares and Kivra backends to set the `X-Correlation-Id` on the response, and only attach the header to incoming requests here (but not the response).